### PR TITLE
Fixed a bug in line parsing. Added tests and ran cargo fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,35 +91,16 @@ mod model;
 use std::result::Result;
 
 pub use model::{
-    Face,
-    FaceElement,
-    Group,
-    Line,
-    LineElement,
-    Model,
-    ModelError,
-    Normal,
-    Point,
-    Texture,
-    Vertex,
+    Face, FaceElement, Group, Line, LineElement, Model, ModelError, Normal, Point, Texture, Vertex,
 };
 
 pub use material::{
-    BumpMap,
-    ColorCorrectedMap,
-    ColorType,
-    DisolveType,
-    Material,
-    MaterialError,
-    NonColorCorrectedMap,
-    ReflectionMap,
+    BumpMap, ColorCorrectedMap, ColorType, DisolveType, Material, MaterialError,
+    NonColorCorrectedMap, ReflectionMap,
 };
 
 use thiserror::Error;
-use tokenizer::{
-    Token,
-    TokenizeError,
-};
+use tokenizer::{Token, TokenizeError};
 
 /// The set of errors which might be generated.
 #[derive(Error, Debug)]

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,24 +1,14 @@
 use std::result::Result;
 
 use crate::{
-    get_on_off_from_str,
-    get_opt_token_float_opt,
-    get_token_float,
-    get_token_int,
-    get_token_string,
+    get_on_off_from_str, get_opt_token_float_opt, get_token_float, get_token_int, get_token_string,
     tokenizer::Token,
 };
 use nom::{
     branch::alt,
-    combinator::{
-        map,
-        opt,
-    },
+    combinator::{map, opt},
     multi::many1,
-    sequence::{
-        preceded,
-        tuple,
-    },
+    sequence::{preceded, tuple},
     IResult,
 };
 use thiserror::Error;
@@ -67,27 +57,27 @@ enum OptionElement {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ColorCorrectedMap {
     /// The name of the texture map file.
-    pub file_name:     String,
+    pub file_name: String,
     /// Enable horizontal texture blending
-    pub blend_u:       Option<bool>,
+    pub blend_u: Option<bool>,
     /// Enable vertical texture blending
-    pub blend_v:       Option<bool>,
+    pub blend_v: Option<bool>,
     /// Enable color correction
     pub color_correct: Option<bool>,
     /// Enables clamping.
-    pub clamp:         Option<bool>,
+    pub clamp: Option<bool>,
     /// Specifies the range over which scalar or color texture
     /// values may vary. Corresponds to the `-mm` option.
     pub texture_range: Option<(f32, f32)>,
     /// Offset the position in the texture map.
-    pub offset:        Option<(f32, Option<f32>, Option<f32>)>,
+    pub offset: Option<(f32, Option<f32>, Option<f32>)>,
     /// Scale the size of the texture pattern.
-    pub scale:         Option<(f32, Option<f32>, Option<f32>)>,
+    pub scale: Option<(f32, Option<f32>, Option<f32>)>,
     /// A turbulance value to apply to the texture.
-    pub turbulance:    Option<(f32, Option<f32>, Option<f32>)>,
+    pub turbulance: Option<(f32, Option<f32>, Option<f32>)>,
     /// Allows the specification of a specific resolution to use
     /// when an image is used as a texture.
-    pub texture_res:   Option<i32>,
+    pub texture_res: Option<i32>,
 }
 
 impl ColorCorrectedMap {
@@ -98,32 +88,32 @@ impl ColorCorrectedMap {
                 OptionElement::FileName(n) => res.file_name = n.clone(),
                 OptionElement::BlendU(b) => {
                     res.blend_u = Some(*b);
-                },
+                }
                 OptionElement::BlendV(b) => {
                     res.blend_v = Some(*b);
-                },
+                }
                 OptionElement::Cc(b) => {
                     res.color_correct = Some(*b);
-                },
+                }
                 OptionElement::Clamp(b) => {
                     res.clamp = Some(*b);
-                },
+                }
                 OptionElement::TextureRange((base, gain)) => {
                     res.texture_range = Some((*base, *gain));
-                },
+                }
                 OptionElement::Offset((x, y, z)) => {
                     res.offset = Some((*x, *y, *z));
-                },
+                }
                 OptionElement::Scale((x, y, z)) => {
                     res.scale = Some((*x, *y, *z));
-                },
+                }
                 OptionElement::Turbulance((x, y, z)) => {
                     res.turbulance = Some((*x, *y, *z));
-                },
+                }
                 OptionElement::TextureRes(tex_res) => {
                     res.texture_res = Some(*tex_res);
-                },
-                _ => {},
+                }
+                _ => {}
             }
         }
         res
@@ -134,28 +124,28 @@ impl ColorCorrectedMap {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct NonColorCorrectedMap {
     /// The name of the texture map file.
-    pub file_name:     String,
+    pub file_name: String,
     /// Enable horizontal texture blending
-    pub blend_u:       Option<bool>,
+    pub blend_u: Option<bool>,
     /// Enable vertical texture blending
-    pub blend_v:       Option<bool>,
+    pub blend_v: Option<bool>,
     /// Enables clamping.
-    pub clamp:         Option<bool>,
+    pub clamp: Option<bool>,
     /// Specifies the channel used to create a scalar or
     /// bump texture.
-    pub imf_chan:      Option<String>,
+    pub imf_chan: Option<String>,
     /// Specifies the range over which scalar or color texture
     /// values may vary. Corresponds to the `-mm` option.
     pub texture_range: Option<(f32, f32)>,
     /// Offset the position in the texture map.
-    pub offset:        Option<(f32, Option<f32>, Option<f32>)>,
+    pub offset: Option<(f32, Option<f32>, Option<f32>)>,
     /// Scale the size of the texture pattern.
-    pub scale:         Option<(f32, Option<f32>, Option<f32>)>,
+    pub scale: Option<(f32, Option<f32>, Option<f32>)>,
     /// A turbulance value to apply to the texture.
-    pub turbulance:    Option<(f32, Option<f32>, Option<f32>)>,
+    pub turbulance: Option<(f32, Option<f32>, Option<f32>)>,
     /// Allows the specification of a specific resolution to use
     /// when an image is used as a texture.
-    pub texture_res:   Option<i32>,
+    pub texture_res: Option<i32>,
 }
 
 impl NonColorCorrectedMap {
@@ -166,30 +156,30 @@ impl NonColorCorrectedMap {
                 OptionElement::FileName(n) => res.file_name = n.clone(),
                 OptionElement::BlendU(b) => {
                     res.blend_u = Some(*b);
-                },
+                }
                 OptionElement::BlendV(b) => {
                     res.blend_v = Some(*b);
-                },
+                }
                 OptionElement::Clamp(b) => {
                     res.clamp = Some(*b);
-                },
+                }
                 OptionElement::ImfChan(chan) => res.imf_chan = Some(chan.clone()),
                 OptionElement::TextureRange((base, gain)) => {
                     res.texture_range = Some((*base, *gain));
-                },
+                }
                 OptionElement::Offset((x, y, z)) => {
                     res.offset = Some((*x, *y, *z));
-                },
+                }
                 OptionElement::Scale((x, y, z)) => {
                     res.scale = Some((*x, *y, *z));
-                },
+                }
                 OptionElement::Turbulance((x, y, z)) => {
                     res.turbulance = Some((*x, *y, *z));
-                },
+                }
                 OptionElement::TextureRes(tex_res) => {
                     res.texture_res = Some(*tex_res);
-                },
-                _ => {},
+                }
+                _ => {}
             }
         }
         res
@@ -202,7 +192,7 @@ pub struct BumpMap {
     /// Specifies a bump multiplier
     pub bump_multiplier: Option<f32>,
     /// Additional map settings.
-    pub map_settings:    Option<NonColorCorrectedMap>,
+    pub map_settings: Option<NonColorCorrectedMap>,
 }
 
 impl BumpMap {
@@ -229,7 +219,7 @@ pub struct ReflectionMap {
     /// Corresponds to `-type` in the specification.
     pub reflection_type: String,
     /// Additional map settings.
-    pub map_settings:    Option<ColorCorrectedMap>,
+    pub map_settings: Option<ColorCorrectedMap>,
 }
 
 impl ReflectionMap {
@@ -254,55 +244,55 @@ impl ReflectionMap {
 pub struct Material {
     /// The name of the material.
     /// Corresponds to `newmtl` in the specification.
-    pub name:                 String,
+    pub name: String,
     /// The ambient reflectivity value.
     /// Corresponds to `Ka` in the specification.
-    pub ambient:              Option<ColorType>,
+    pub ambient: Option<ColorType>,
     /// The diffuse reflectivity value
     /// Corresponds to `Kd` in the specification.
-    pub diffuse:              Option<ColorType>,
+    pub diffuse: Option<ColorType>,
     /// The specular reflectivity value
     /// Corresponds to `Ks` in the specification.
-    pub specular:             Option<ColorType>,
+    pub specular: Option<ColorType>,
     /// The specular exponent.
     /// Corresponds to `Ns` in the specification.
-    pub specular_exponent:    Option<f32>,
+    pub specular_exponent: Option<f32>,
     /// The disolve.
     /// Corresponds to `d` in the specification.
-    pub disolve:              Option<DisolveType>,
+    pub disolve: Option<DisolveType>,
     /// Transparancy.
     /// Corresponds to `Tr` in the specification.
-    pub transparancy:         Option<f32>,
+    pub transparancy: Option<f32>,
     /// Transmission factor.
     /// Corresponds to `Tf` in the specification.
-    pub transmission_factor:  Option<ColorType>,
+    pub transmission_factor: Option<ColorType>,
     /// Corresponds to `sharpness` in the specification.
-    pub sharpness:            Option<f32>,
+    pub sharpness: Option<f32>,
     /// Corresponds to `Ni` in the specification.
-    pub index_of_refraction:  Option<f32>,
+    pub index_of_refraction: Option<f32>,
     /// Corresponds to `illum` in the specification.
-    pub illumination_mode:    Option<u32>,
+    pub illumination_mode: Option<u32>,
     /// Corresponds to `map_Ka` in the specification.
-    pub texture_map_ambient:  Option<ColorCorrectedMap>,
+    pub texture_map_ambient: Option<ColorCorrectedMap>,
     /// Corresponds to `map_Kd` in the specification.
-    pub texture_map_diffuse:  Option<ColorCorrectedMap>,
+    pub texture_map_diffuse: Option<ColorCorrectedMap>,
     /// Corresponds to `map_Ks` in the specification.
     pub texture_map_specular: Option<ColorCorrectedMap>,
     /// Corresponds to `map_Ns` in the specification.
-    pub shininess_map:        Option<NonColorCorrectedMap>,
+    pub shininess_map: Option<NonColorCorrectedMap>,
     /// Corresponds to `map_d` in the specification.
-    pub disolve_map:          Option<NonColorCorrectedMap>,
+    pub disolve_map: Option<NonColorCorrectedMap>,
     /// Corresponds to `disp` in the specification.
-    pub displacement_map:     Option<NonColorCorrectedMap>,
+    pub displacement_map: Option<NonColorCorrectedMap>,
     /// Corresponds to `decal` in the specification.
-    pub decal:                Option<NonColorCorrectedMap>,
+    pub decal: Option<NonColorCorrectedMap>,
     /// Corresponds to `bump` in the specification.
-    pub bump_map:             Option<BumpMap>,
+    pub bump_map: Option<BumpMap>,
     /// Corresponds to `refl` in the specification.
-    pub reflection_map:       Option<ReflectionMap>,
+    pub reflection_map: Option<ReflectionMap>,
     /// Enables/Disables anti-aliasing of textures in THIS material only.
     /// Corresponds to `map_aat` in the specification.
-    pub anti_alias_map:       Option<bool>,
+    pub anti_alias_map: Option<bool>,
 }
 
 impl Material {
@@ -310,67 +300,67 @@ impl Material {
         match element {
             MaterialElement::Name(n) => {
                 self.name = n.clone();
-            },
+            }
             MaterialElement::Ambient(c) => {
                 self.ambient = Some(c.clone());
-            },
+            }
             MaterialElement::Diffuse(c) => {
                 self.diffuse = Some(c.clone());
-            },
+            }
             MaterialElement::Specular(c) => {
                 self.specular = Some(c.clone());
-            },
+            }
             MaterialElement::SpecularExponent(f) => {
                 self.specular_exponent = Some(*f);
-            },
+            }
             MaterialElement::Disolve(d) => {
                 self.disolve = Some(*d);
-            },
+            }
             MaterialElement::Transparency(f) => {
                 self.transparancy = Some(*f);
-            },
+            }
             MaterialElement::TransmissionFactor(c) => {
                 self.transmission_factor = Some(c.clone());
-            },
+            }
             MaterialElement::Sharpness(f) => {
                 self.sharpness = Some(*f);
-            },
+            }
             MaterialElement::IndexOfRefraction(f) => {
                 self.index_of_refraction = Some(*f);
-            },
+            }
             MaterialElement::IlluminationModel(u) => {
                 self.illumination_mode = Some(*u);
-            },
+            }
             MaterialElement::TexMapAmbient(cc) => {
                 self.texture_map_ambient = Some(cc.clone());
-            },
+            }
             MaterialElement::TexMapDiffuse(cc) => {
                 self.texture_map_diffuse = Some(cc.clone());
-            },
+            }
             MaterialElement::TexMapSpecular(cc) => {
                 self.texture_map_specular = Some(cc.clone());
-            },
+            }
             MaterialElement::ShininessMap(ncc) => {
                 self.shininess_map = Some(ncc.clone());
-            },
+            }
             MaterialElement::DisolveMap(ncc) => {
                 self.disolve_map = Some(ncc.clone());
-            },
+            }
             MaterialElement::DisplacementMap(ncc) => {
                 self.displacement_map = Some(ncc.clone());
-            },
+            }
             MaterialElement::Decal(ncc) => {
                 self.decal = Some(ncc.clone());
-            },
+            }
             MaterialElement::BumpMap(bm) => {
                 self.bump_map = Some(bm.clone());
-            },
+            }
             MaterialElement::ReflectionMap(rm) => {
                 self.reflection_map = Some(rm.clone());
-            },
+            }
             MaterialElement::AntiAliasMap(b) => {
                 self.anti_alias_map = Some(*b);
-            },
+            }
         }
     }
 }
@@ -471,7 +461,7 @@ fn parse_new_material(input: &[Token]) -> IResult<&[Token], MaterialElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::Name(name)
         },
@@ -492,14 +482,14 @@ fn parse_color_type(input: &[Token]) -> IResult<&[Token], ColorType> {
                     Err(e) => {
                         log::error!("{}", e);
                         Default::default()
-                    },
+                    }
                 };
                 let factor = match get_opt_token_float_opt(&factor) {
                     Ok(s) => s.unwrap_or(1.0),
                     Err(e) => {
                         log::error!("{}", e);
                         Default::default()
-                    },
+                    }
                 };
                 ColorType::Spectral(file_name, factor)
             },
@@ -517,7 +507,7 @@ fn parse_color_type(input: &[Token]) -> IResult<&[Token], ColorType> {
                     Err(e) => {
                         log::error!("{}", e);
                         Default::default()
-                    },
+                    }
                 };
                 let y = match y_token {
                     Some(y) => match get_token_float(&y) {
@@ -525,7 +515,7 @@ fn parse_color_type(input: &[Token]) -> IResult<&[Token], ColorType> {
                         Err(e) => {
                             log::error!("{}", e);
                             Default::default()
-                        },
+                        }
                     },
                     None => x,
                 };
@@ -535,7 +525,7 @@ fn parse_color_type(input: &[Token]) -> IResult<&[Token], ColorType> {
                         Err(e) => {
                             log::error!("{}", e);
                             Default::default()
-                        },
+                        }
                     },
                     None => x,
                 };
@@ -556,21 +546,21 @@ fn parse_color_type(input: &[Token]) -> IResult<&[Token], ColorType> {
                         Err(e) => {
                             log::error!("{}", e);
                             Default::default()
-                        },
+                        }
                     },
                     match get_token_float(&g) {
                         Ok(s) => s,
                         Err(e) => {
                             log::error!("{}", e);
                             Default::default()
-                        },
+                        }
                     },
                     match get_token_float(&b) {
                         Ok(s) => s,
                         Err(e) => {
                             log::error!("{}", e);
                             Default::default()
-                        },
+                        }
                     },
                 );
 
@@ -610,7 +600,7 @@ fn parse_specular_exponent(input: &[Token]) -> IResult<&[Token], MaterialElement
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::SpecularExponent(f)
         }),
@@ -632,7 +622,7 @@ fn parse_disolve(input: &[Token]) -> IResult<&[Token], MaterialElement> {
                         Err(e) => {
                             log::error!("{}", e);
                             Default::default()
-                        },
+                        }
                     };
                     MaterialElement::Disolve(DisolveType::Halo(f))
                 },
@@ -643,7 +633,7 @@ fn parse_disolve(input: &[Token]) -> IResult<&[Token], MaterialElement> {
                     Err(e) => {
                         log::error!("{}", e);
                         Default::default()
-                    },
+                    }
                 };
                 MaterialElement::Disolve(DisolveType::Alpha(f))
             }),
@@ -660,7 +650,7 @@ fn parse_transparency(input: &[Token]) -> IResult<&[Token], MaterialElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::Transparency(f)
         }),
@@ -683,7 +673,7 @@ fn parse_sharpness(input: &[Token]) -> IResult<&[Token], MaterialElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::Sharpness(f)
         }),
@@ -699,7 +689,7 @@ fn parse_index_of_refraction(input: &[Token]) -> IResult<&[Token], MaterialEleme
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::IndexOfRefraction(f)
         }),
@@ -715,7 +705,7 @@ fn parse_illumination_model(input: &[Token]) -> IResult<&[Token], MaterialElemen
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::IlluminationModel(f as u32)
         }),
@@ -812,7 +802,7 @@ fn parse_anti_alias_map(input: &[Token]) -> IResult<&[Token], MaterialElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             MaterialElement::AntiAliasMap(val)
         }),
@@ -838,7 +828,7 @@ fn parse_options(input: &[Token]) -> IResult<&[Token], Vec<OptionElement>> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::FileName(name)
         }),
@@ -858,7 +848,7 @@ fn parse_option_blend(input: &[Token]) -> IResult<&[Token], OptionElement> {
                     Err(e) => {
                         log::error!("{}", e);
                         Default::default()
-                    },
+                    }
                 };
                 OptionElement::BlendU(val)
             },
@@ -874,7 +864,7 @@ fn parse_option_blend(input: &[Token]) -> IResult<&[Token], OptionElement> {
                     Err(e) => {
                         log::error!("{}", e);
                         Default::default()
-                    },
+                    }
                 };
                 OptionElement::BlendV(val)
             },
@@ -894,7 +884,7 @@ fn parse_option_bm(input: &[Token]) -> IResult<&[Token], OptionElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::BumpMultiplier(val)
         },
@@ -913,7 +903,7 @@ fn parse_option_cc(input: &[Token]) -> IResult<&[Token], OptionElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::Cc(val)
         },
@@ -932,7 +922,7 @@ fn parse_option_clamp(input: &[Token]) -> IResult<&[Token], OptionElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::Clamp(val)
         },
@@ -951,14 +941,14 @@ fn parse_option_texture_range(input: &[Token]) -> IResult<&[Token], OptionElemen
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             let gain = match get_token_float(&gain) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::TextureRange((base, gain))
         },
@@ -981,21 +971,21 @@ fn parse_option_offset(input: &[Token]) -> IResult<&[Token], OptionElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             let y = match get_opt_token_float_opt(&y) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     None
-                },
+                }
             };
             let z = match get_opt_token_float_opt(&z) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     None
-                },
+                }
             };
             OptionElement::Offset((x, y, z))
         },
@@ -1018,21 +1008,21 @@ fn parse_option_scale(input: &[Token]) -> IResult<&[Token], OptionElement> {
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             let y = match get_opt_token_float_opt(&y) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     None
-                },
+                }
             };
             let z = match get_opt_token_float_opt(&z) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     None
-                },
+                }
             };
             OptionElement::Scale((x, y, z))
         },
@@ -1055,21 +1045,21 @@ fn parse_option_turbulance(input: &[Token]) -> IResult<&[Token], OptionElement> 
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             let y = match get_opt_token_float_opt(&y) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     None
-                },
+                }
             };
             let z = match get_opt_token_float_opt(&z) {
                 Ok(s) => s,
                 Err(e) => {
                     log::error!("{}", e);
                     None
-                },
+                }
             };
             OptionElement::Turbulance((x, y, z))
         },
@@ -1088,7 +1078,7 @@ fn parse_option_texture_resolution(input: &[Token]) -> IResult<&[Token], OptionE
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::TextureRes(val)
         },
@@ -1107,7 +1097,7 @@ fn parse_option_imf_channel(input: &[Token]) -> IResult<&[Token], OptionElement>
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::ImfChan(val)
         },
@@ -1126,7 +1116,7 @@ fn parse_option_reflection_type(input: &[Token]) -> IResult<&[Token], OptionElem
                 Err(e) => {
                     log::error!("{}", e);
                     Default::default()
-                },
+                }
             };
             OptionElement::ReflectionType(val)
         },

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -27,24 +27,24 @@ fn parse_double_comment_test() {
     assert_eq!(
         face.elements[0],
         FaceElement {
-            vertex_index:  11250,
-            normal_index:  Some(11250),
+            vertex_index: 11250,
+            normal_index: Some(11250),
             texture_index: None,
         }
     );
     assert_eq!(
         face.elements[1],
         FaceElement {
-            vertex_index:  4406,
-            normal_index:  Some(4406),
+            vertex_index: 4406,
+            normal_index: Some(4406),
             texture_index: None,
         }
     );
     assert_eq!(
         face.elements[2],
         FaceElement {
-            vertex_index:  31248,
-            normal_index:  Some(31248),
+            vertex_index: 31248,
+            normal_index: Some(31248),
             texture_index: None,
         }
     );
@@ -52,24 +52,24 @@ fn parse_double_comment_test() {
     assert_eq!(
         face.elements[0],
         FaceElement {
-            vertex_index:  9238,
-            normal_index:  Some(9238),
+            vertex_index: 9238,
+            normal_index: Some(9238),
             texture_index: None,
         }
     );
     assert_eq!(
         face.elements[1],
         FaceElement {
-            vertex_index:  25314,
-            normal_index:  Some(25314),
+            vertex_index: 25314,
+            normal_index: Some(25314),
             texture_index: None,
         }
     );
     assert_eq!(
         face.elements[2],
         FaceElement {
-            vertex_index:  21852,
-            normal_index:  Some(21852),
+            vertex_index: 21852,
+            normal_index: Some(21852),
             texture_index: None,
         }
     );

--- a/src/test/mtl.rs
+++ b/src/test/mtl.rs
@@ -1,17 +1,9 @@
 use crate::{
     material::{
-        BumpMap,
-        ColorCorrectedMap,
-        ColorType,
-        DisolveType,
-        Material,
-        NonColorCorrectedMap,
+        BumpMap, ColorCorrectedMap, ColorType, DisolveType, Material, NonColorCorrectedMap,
         ReflectionMap,
     },
-    tokenizer::{
-        parse_mtl,
-        Token,
-    },
+    tokenizer::{parse_mtl, Token},
 };
 
 #[test]
@@ -413,7 +405,7 @@ parse_material_test!(
         }),
         bump_map: Some(BumpMap {
             bump_multiplier: Some(2.0),
-            map_settings:    Some(NonColorCorrectedMap {
+            map_settings: Some(NonColorCorrectedMap {
                 file_name: "leath.mpb".into(),
                 ..Default::default()
             }),
@@ -473,7 +465,7 @@ parse_material_test!(
         illumination_mode: Some(1),
         reflection_map: Some(ReflectionMap {
             reflection_type: "sphere".into(),
-            map_settings:    Some(ColorCorrectedMap {
+            map_settings: Some(ColorCorrectedMap {
                 file_name: "chrome.rla".into(),
                 ..Default::default()
             }),

--- a/src/test/obj.rs
+++ b/src/test/obj.rs
@@ -1,13 +1,9 @@
+use crate::model::ModelElement;
 use crate::{
-    model::{
-        Face,
-        FaceElement,
-        Vertex,
-    },
-    tokenizer::{
-        parse_obj,
-        Token,
-    },
+    model,
+    model::{Face, FaceElement, Vertex},
+    tokenizer::{parse_obj, Token},
+    Line, LineElement, Material, Point, Texture,
 };
 
 #[test]
@@ -99,6 +95,39 @@ fn parse_vertex_texture() {
     assert_eq!(tokens[0], Token::VertexTexture);
     assert_eq!(tokens[1], Token::Float(0.500));
     assert_eq!(tokens[2], Token::Int(1));
+
+    let res = model::parse_vertex_texture(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, texture) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    let expected = Texture {
+        u: 0.500,
+        v: Some(1.0),
+        w: None,
+    };
+    assert_eq!(texture, expected);
+}
+
+#[test]
+fn parse_vertex_texture2() {
+    let vert = "vt 0.500 1 0.75";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+
+    let res = model::parse_vertex_texture(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, texture) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    let expected = Texture {
+        u: 0.500,
+        v: Some(1.0),
+        w: Some(0.75),
+    };
+    assert_eq!(texture, expected);
 }
 
 #[test]
@@ -113,6 +142,34 @@ fn parse_face() {
     assert_eq!(tokens[1], Token::Int(1));
     assert_eq!(tokens[2], Token::Int(2));
     assert_eq!(tokens[3], Token::Int(3));
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 3);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: None,
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: None,
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: None,
+                normal_index: None,
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
 }
 
 #[test]
@@ -133,6 +190,33 @@ fn parse_face_1() {
     assert_eq!(tokens[7], Token::Int(3));
     assert_eq!(tokens[8], Token::Slash);
     assert_eq!(tokens[9], Token::Int(4));
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 3);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: Some(2),
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: Some(3),
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: Some(4),
+                normal_index: None,
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
 }
 
 #[test]
@@ -159,6 +243,33 @@ fn parse_face_2() {
     assert_eq!(tokens[13], Token::Int(4));
     assert_eq!(tokens[14], Token::Slash);
     assert_eq!(tokens[15], Token::Int(5));
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 3);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: Some(2),
+                normal_index: Some(3),
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: Some(3),
+                normal_index: Some(4),
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: Some(4),
+                normal_index: Some(5),
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
 }
 
 #[test]
@@ -182,6 +293,177 @@ fn parse_face_3() {
     assert_eq!(tokens[10], Token::Slash);
     assert_eq!(tokens[11], Token::Slash);
     assert_eq!(tokens[12], Token::Int(4));
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 3);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: None,
+                normal_index: Some(2),
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: None,
+                normal_index: Some(3),
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: None,
+                normal_index: Some(4),
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
+}
+
+#[test]
+fn parse_face_4() {
+    //According to http://paulbourke.net/dataformats/obj/ this is illegal syntax
+    //As a leniant parser it should parse ok
+    let vert = "f 1/1/1 2/2/2 3//3 4//4";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 4);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: Some(1),
+                normal_index: Some(1),
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: Some(2),
+                normal_index: Some(2),
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: None,
+                normal_index: Some(3),
+            },
+            FaceElement {
+                vertex_index: 4,
+                texture_index: None,
+                normal_index: Some(4),
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
+}
+
+#[test]
+#[ignore]
+fn parse_face_trailing_slash() {
+    //This could be an edge case but it is my interpretation that this is legal
+    let vert = "f 1/ 2/ 3/";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 3);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: None,
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: None,
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: None,
+                normal_index: None,
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
+}
+
+#[test]
+#[ignore]
+fn parse_face_trailing_slash_slash() {
+    //This could be an edge case but it is my interpretation that this is legal
+    let vert = "f 1// 2// 3//";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+
+    let res = model::parse_face(&tokens);
+    dbg!(&res);
+    let (extra, face) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(face.elements.len(), 3);
+    let expected = Face {
+        elements: vec![
+            FaceElement {
+                vertex_index: 1,
+                texture_index: None,
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 2,
+                texture_index: None,
+                normal_index: None,
+            },
+            FaceElement {
+                vertex_index: 3,
+                texture_index: None,
+                normal_index: None,
+            },
+        ],
+        smoothing_group: 0,
+    };
+    assert_eq!(face, expected);
+}
+
+#[test]
+fn parse_point() {
+    let vert = "p 1 2 3";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+    assert_eq!(tokens.len(), 4);
+    assert_eq!(tokens[0], Token::Point);
+    assert_eq!(tokens[1], Token::Int(1));
+    assert_eq!(tokens[2], Token::Int(2));
+    assert_eq!(tokens[3], Token::Int(3));
+
+    let res = model::parse_point(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, point) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(point.elements.len(), 3);
+    let expected = Point {
+        elements: vec![1, 2, 3],
+    };
+    assert_eq!(point, expected);
 }
 
 #[test]
@@ -196,6 +478,96 @@ fn parse_line() {
     assert_eq!(tokens[1], Token::Int(1));
     assert_eq!(tokens[2], Token::Int(2));
     assert_eq!(tokens[3], Token::Int(3));
+
+    let res = model::parse_line(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, line) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(line.elements.len(), 3);
+    let expected = Line {
+        elements: vec![
+            LineElement {
+                vertex_index: 1,
+                texture_index: None,
+            },
+            LineElement {
+                vertex_index: 2,
+                texture_index: None,
+            },
+            LineElement {
+                vertex_index: 3,
+                texture_index: None,
+            },
+        ],
+    };
+    assert_eq!(line, expected);
+}
+
+#[test]
+fn parse_line_texture_struct() {
+    let vert = "l 1/4 2/5 3/6";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+    let res = model::parse_line(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, line) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(line.elements.len(), 3);
+    let expected = Line {
+        elements: vec![
+            LineElement {
+                vertex_index: 1,
+                texture_index: Some(4),
+            },
+            LineElement {
+                vertex_index: 2,
+                texture_index: Some(5),
+            },
+            LineElement {
+                vertex_index: 3,
+                texture_index: Some(6),
+            },
+        ],
+    };
+    assert_eq!(line, expected);
+}
+
+#[test]
+#[ignore]
+fn parse_line_trailing_slash_struct() {
+    //This could be an edge case but it is my interpretation that this is legal
+    let vert = "l 1/ 2/ 3/";
+    let res = parse_obj(vert);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let tokens = res.unwrap();
+    let res = model::parse_line(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, line) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+    assert_eq!(line.elements.len(), 3);
+    let expected = Line {
+        elements: vec![
+            LineElement {
+                vertex_index: 1,
+                texture_index: None,
+            },
+            LineElement {
+                vertex_index: 2,
+                texture_index: None,
+            },
+            LineElement {
+                vertex_index: 3,
+                texture_index: None,
+            },
+        ],
+    };
+    assert_eq!(line, expected);
 }
 
 #[test]
@@ -208,6 +580,17 @@ fn simple_material() {
     assert_eq!(tokens.len(), 2);
     assert_eq!(tokens[0], Token::MaterialLib);
     assert_eq!(tokens[1], Token::String("some_mtl_file.mtl".to_string()));
+
+    let res = model::parse_mat_lib(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, model) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+
+    assert_eq!(
+        model,
+        ModelElement::MaterialLib(vec!["some_mtl_file.mtl".to_string()])
+    );
 }
 
 #[test]
@@ -220,6 +603,14 @@ fn simple_group() {
     assert_eq!(tokens.len(), 2);
     assert_eq!(tokens[0], Token::Group);
     assert_eq!(tokens[1], Token::String("some_group".to_string()));
+
+    let res = model::parse_group(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, model) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+
+    assert_eq!(model, ModelElement::Group(vec!["some_group".to_string()]));
 }
 
 #[test]
@@ -232,6 +623,14 @@ fn simple_object() {
     assert_eq!(tokens.len(), 2);
     assert_eq!(tokens[0], Token::Object);
     assert_eq!(tokens[1], Token::String("some_object".to_string()));
+
+    let res = model::parse_obj_name(&tokens);
+    dbg!(&res);
+    assert!(res.is_ok());
+    let (extra, model) = res.ok().unwrap();
+    assert_eq!(extra.len(), 0);
+
+    assert_eq!(model, ModelElement::ObjName("some_object".to_string()));
 }
 
 #[test]
@@ -265,6 +664,538 @@ fn cube_test() {
     f 5 8 4 1
     f 6 7 8 5
     
+    # End of file
+    ";
+
+    let res = crate::load_obj(&input).unwrap();
+    dbg!(&res);
+    assert_eq!(res.vertices.len(), 8);
+    assert_eq!(
+        res.vertices[0],
+        Vertex {
+            x: -0.5,
+            y: -0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[1],
+        Vertex {
+            x: -0.5,
+            y: -0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[2],
+        Vertex {
+            x: -0.5,
+            y: 0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[3],
+        Vertex {
+            x: -0.5,
+            y: 0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[4],
+        Vertex {
+            x: 0.5,
+            y: -0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[5],
+        Vertex {
+            x: 0.5,
+            y: -0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[6],
+        Vertex {
+            x: 0.5,
+            y: 0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[7],
+        Vertex {
+            x: 0.5,
+            y: 0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+
+    let group = &res.groups["default"];
+    assert_eq!(group.material_name, "Default".to_string());
+    assert_eq!(res.normals.len(), 0);
+    assert_eq!(res.faces.len(), 1);
+    let face_group = &res.faces["default"];
+    assert_eq!(face_group.len(), 6);
+    assert_eq!(
+        face_group[0],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 4,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 3,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 2,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 1,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[1],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 2,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 6,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 5,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 1,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[2],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 3,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 7,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 6,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 2,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[3],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 8,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 7,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 3,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 4,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[4],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 5,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 8,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 4,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 1,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[5],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 6,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 7,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 8,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 5,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn cube_test_interspersed() {
+    let input = "#	                Vertices: 8
+    #	                  Points: 0
+    #	                   Lines: 0
+    #	                   Faces: 6
+    #	               Materials: 1
+
+    o 1
+
+    usemtl Default
+    # Vertex list
+
+    v -0.5 -0.5 0.5
+    v -0.5 -0.5 -0.5
+    v -0.5 0.5 -0.5
+    v -0.5 0.5 0.5
+    f 4 3 2 1
+
+    v 0.5 -0.5 0.5
+    v 0.5 -0.5 -0.5
+    f 2 6 5 1
+
+    v 0.5 0.5 -0.5
+    f 3 7 6 2
+    v 0.5 0.5 0.5
+
+    f 8 7 3 4
+    f 5 8 4 1
+    f 6 7 8 5
+
+    # End of file
+    ";
+
+    let res = crate::load_obj(&input).unwrap();
+    dbg!(&res);
+    assert_eq!(res.vertices.len(), 8);
+    assert_eq!(
+        res.vertices[0],
+        Vertex {
+            x: -0.5,
+            y: -0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[1],
+        Vertex {
+            x: -0.5,
+            y: -0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[2],
+        Vertex {
+            x: -0.5,
+            y: 0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[3],
+        Vertex {
+            x: -0.5,
+            y: 0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[4],
+        Vertex {
+            x: 0.5,
+            y: -0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[5],
+        Vertex {
+            x: 0.5,
+            y: -0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[6],
+        Vertex {
+            x: 0.5,
+            y: 0.5,
+            z: -0.5,
+            w: None,
+        }
+    );
+    assert_eq!(
+        res.vertices[7],
+        Vertex {
+            x: 0.5,
+            y: 0.5,
+            z: 0.5,
+            w: None,
+        }
+    );
+
+    let group = &res.groups["default"];
+    assert_eq!(group.material_name, "Default".to_string());
+    assert_eq!(res.normals.len(), 0);
+    assert_eq!(res.faces.len(), 1);
+    let face_group = &res.faces["default"];
+    assert_eq!(face_group.len(), 6);
+    assert_eq!(
+        face_group[0],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 4,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 3,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 2,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 1,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[1],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 2,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 6,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 5,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 1,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[2],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 3,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 7,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 6,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 2,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[3],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 8,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 7,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 3,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 4,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[4],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 5,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 8,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 4,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 1,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        face_group[5],
+        Face {
+            elements: vec![
+                FaceElement {
+                    vertex_index: 6,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 7,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 8,
+                    ..Default::default()
+                },
+                FaceElement {
+                    vertex_index: 5,
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+#[ignore]
+fn cube_test_minus() {
+    let input = "#	                Vertices: 8
+    #	                  Points: 0
+    #	                   Lines: 0
+    #	                   Faces: 6
+    #	               Materials: 1
+
+    o 1
+
+    # Vertex list
+
+    v -0.5 -0.5 0.5
+    v -0.5 -0.5 -0.5
+    v -0.5 0.5 -0.5
+    v -0.5 0.5 0.5
+    v 0.5 -0.5 0.5
+    v 0.5 -0.5 -0.5
+    v 0.5 0.5 -0.5
+    v 0.5 0.5 0.5
+
+    # Point/Line/Face list
+
+    usemtl Default
+    # f 4 3 2 1
+    # f 2 6 5 1
+    # f 3 7 6 2
+    # f 8 7 3 4
+    # f 5 8 4 1
+    # f 6 7 8 5
+
+    f -5 -6 -7 -8
+    f -7 -3 -4 -8
+    f -6 -2 -3 -7
+    f -1 -2 -6 -5
+    f -4 -1 -5 -8
+    f -3 -2 -1 -4
+
     # End of file
     ";
 

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -9,14 +9,8 @@ use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::digit1,
-    combinator::{
-        map,
-        opt,
-    },
-    multi::{
-        fold_many0,
-        fold_many1,
-    },
+    combinator::{map, opt},
+    multi::{fold_many0, fold_many1},
     sequence::tuple,
     IResult,
 };

--- a/src/tokenizer/mtl.rs
+++ b/src/tokenizer/mtl.rs
@@ -2,28 +2,14 @@ use std::result::Result;
 
 use nom::{
     branch::alt,
-    bytes::complete::{
-        is_not,
-        tag,
-        tag_no_case,
-    },
-    character::complete::{
-        line_ending,
-        multispace0,
-        multispace1,
-    },
+    bytes::complete::{is_not, tag, tag_no_case},
+    character::complete::{line_ending, multispace0, multispace1},
     combinator::map,
     multi::fold_many0,
-    sequence::{
-        delimited,
-        preceded,
-    },
+    sequence::{delimited, preceded},
 };
 
-use super::{
-    Token,
-    TokenizeError,
-};
+use super::{Token, TokenizeError};
 
 pub fn parse_mtl(input: &str) -> Result<Vec<Token>, TokenizeError> {
     match fold_many0(

--- a/src/tokenizer/obj.rs
+++ b/src/tokenizer/obj.rs
@@ -2,28 +2,14 @@ use std::result::Result;
 
 use nom::{
     branch::alt,
-    bytes::complete::{
-        is_not,
-        tag,
-        tag_no_case,
-    },
-    character::complete::{
-        line_ending,
-        multispace0,
-        multispace1,
-    },
+    bytes::complete::{is_not, tag, tag_no_case},
+    character::complete::{line_ending, multispace0, multispace1},
     combinator::map,
     multi::fold_many0,
-    sequence::{
-        delimited,
-        preceded,
-    },
+    sequence::{delimited, preceded},
 };
 
-use super::{
-    Token,
-    TokenizeError,
-};
+use super::{Token, TokenizeError};
 
 pub fn parse_obj(input: &str) -> Result<Vec<Token>, TokenizeError> {
     match fold_many0(

--- a/src/tokenizer/test.rs
+++ b/src/tokenizer/test.rs
@@ -1,7 +1,4 @@
-use super::{
-    parse_digit,
-    parse_float,
-};
+use super::{parse_digit, parse_float};
 use crate::tokenizer::Token;
 
 macro_rules! parse_digit_test {


### PR DESCRIPTION
I found a problem with line parsing and fixed it.

My fix is:
```
tuple((
                    token_match!(Token::Int(_)),
                    opt(preceded(
                        token_match!(Token::Slash),
                        opt(token_match!(Token::Int(_))),
                    )),
```

There are several tests that I created and marked ignore (as they dont pass), some are edge cases that may or may not be valid syntax, but I would expect a lenient parser to handle them.

One of the things obj files allow is negative vertex indexes -1 refers to the last vertex defined, however, currently there appears to be no easy way to implement that. 

Nom would have to have some global state, maybe the vector of vertices, 
-n could be replaced by vertices.len()-n, i.e. -1 is vertices.len()-1

Or if you wanted to enable round tripping you could store the current length in the Vertex struct

 I put some tests in showing what the expected result would be,

Im not sure now if it was a good idea but I ran cargo fmt. And now have no easy way to go back.... hope thats ok 

Thanks for the crate.